### PR TITLE
Add Markdown Support and Default to Intelligent Paste

### DIFF
--- a/background.js
+++ b/background.js
@@ -117,13 +117,14 @@ Action = {
 		
 		// Extraction des URL, soit ligne par ligne, soit intelligent paste
 		if( localStorage["intelligent_paste"] == "true" ){
-			var urlList = clipboardString.match(/(https?|ftp|ssh|mailto):\/\/[a-z0-9\/:%_+.,#?!@&=-]+/gi);
+			// Extraction des URL intelligent (http/https/ftp/ssh/mailto) avec la possibilité d'ignorer les liens Markdown
+			var urlList = Array.from(clipboardString.matchAll(/(?:\[.*?\]\()?((?:https?|ftp|ssh|mailto):\/\/[a-z0-9\/:%_+.,#?!@&=-]+)/gi), match => match[1]);
 		} else {
 			var urlList = clipboardString.split("\n");
 		}
 		
 		// Si urlList est vide, on affiche un message d'erreur et on sort
-		if (urlList == null) {
+		if (urlList == null || urlList.length == 0) {
 			chrome.runtime.sendMessage({type: "paste", errorMsg: "No URL found in the clipboard"});
 			return;
 		}
@@ -145,6 +146,12 @@ Action = {
 			}
 			return true;
 		});
+
+		// Après le filtrage s'il n'y a plus d'URL valides, on affiche un message d'erreur et on sort
+		if (urlList.length == 0) {
+			chrome.runtime.sendMessage({type: "paste", errorMsg: "No URL found in the clipboard"});
+			return;
+		}
 		
 		// Ouverture de toutes les URLs dans des onglets
 		$.each(urlList, function(key, val){

--- a/background.js
+++ b/background.js
@@ -116,7 +116,7 @@ Action = {
 		var clipboardString = Clipboard.read();
 		
 		// Extraction des URL, soit ligne par ligne, soit intelligent paste
-		if( localStorage["intelligent_paste"] == "true" ){
+		if( typeof localStorage["intelligent_paste"] === 'undefined' || localStorage["intelligent_paste"] == "true" ){
 			// Extraction des URL intelligent (http/https/ftp/ssh/mailto) avec la possibilité d'ignorer les liens Markdown
 			var urlList = Array.from(clipboardString.matchAll(/(?:\[.*?\]\()?((?:https?|ftp|ssh|mailto):\/\/[a-z0-9\/:%_+.,#?!@&=-]+)/gi), match => match[1]);
 		} else {
@@ -353,7 +353,7 @@ AnalyticsHelper = {
 			da: localStorage['default_action'] ? localStorage['default_action'] : "menu",
 			mm: localStorage['mime'] ? localStorage['mime'] : 'plaintext',
 			hl: localStorage['highlighted_tab_only'] == "true" ? 1 : 0,
-			ip: localStorage['intelligent_paste'] == "true" ? 1 : 0,
+			ip: localStorage['intelligent_paste'] ? (localStorage['intelligent_paste'] == "true" ? 1 : 0) : 1, // default to 1
 			ww: localStorage['walk_all_windows'] == "true" ? 1 : 0
 		};
 		
@@ -374,7 +374,7 @@ AnalyticsHelper = {
 				break;
 			case "paste":
 				var shortSettings = {
-					ip: localStorage['intelligent_paste'] == "true" ? 1 : 0
+					ip: localStorage['intelligent_paste'] ? (localStorage['intelligent_paste'] == "true" ? 1 : 0) : 1 // default to 1
 				};
 				break;
 		}

--- a/options.html
+++ b/options.html
@@ -107,7 +107,7 @@ body{background:#F0F0F0;}
 			<div id="misc">
 				<div>
 					<label class="checkbox"><input type="checkbox" name="intelligent_paste" id="intelligent_paste" value="on"> Intelligent paste</label>
-					<div class="help">Extract URLs from raw text when using paste feature (instead of processing pasted text line by line, with 1 line = 1 url). The only pitfall using this feature is that it doesn't get &quot;special urls&quot; like ones beginning with <code>file:///</code> or <code>chrome://</code>...</div>
+					<div class="help">Extract URLs from raw text or markdown (instead of processing line by line, where 1 line = 1 url). The only pitfall using this feature is that it doesn't get &quot;special urls&quot; like ones beginning with <code>file:///</code> or <code>chrome://</code>...</div>
 				</div>
 				<div>
 					<label class="checkbox"><input type="checkbox" name="highlighted_tab_only" id="highlighted_tab_only" value="on"> 

--- a/options.js
+++ b/options.js
@@ -165,7 +165,7 @@ var OptionFormManager = {
 		var format = localStorage['format'] ? localStorage['format'] : 'text';
 		var anchor = localStorage['anchor'] ? localStorage['anchor'] : 'url';
 		var format_custom_advanced = localStorage['format_custom_advanced'] ? localStorage['format_custom_advanced'] : '';
-		var intelligent_paste = localStorage['intelligent_paste'] == "true" ? true : false;
+		var intelligent_paste = localStorage['intelligent_paste'] ? (localStorage['intelligent_paste'] == "true" ? true : false) : true; // default to true
 		var walk_all_windows = localStorage['walk_all_windows'] == "true" ? true : false;
 		var highlighted_tab_only = localStorage['highlighted_tab_only'] == "true" ? true : false;
 		var default_action = localStorage['default_action'] ? localStorage['default_action'] : "menu";


### PR DESCRIPTION
This PR contains two changes:

### Markdown

Added the ability to paste markdown links when using the intelligent paste.

Personally this has been an issue when copying a list of links from [Notion](https://www.notion.so/).

Example clipboard:

```markdown
[https://github.com/vincepare/CopyAllUrl_Chrome/](https://github.com/vincepare/CopyAllUrl_Chrome/)
[Support](https://github.com/vincepare/CopyAllUrl_Chrome/issues)
```

converted to

```
https://github.com/vincepare/CopyAllUrl_Chrome/
https://github.com/vincepare/CopyAllUrl_Chrome/issues
```

### Turn on Intelligent Paste by Default

Intelligent paste is probably more useful for most use cases. The odds that someone is pasting "file://" or "chrome://" links is quite low. For that special use case they could turn off Intelligent paste.